### PR TITLE
Remove deprecation warnings with php 8.1

### DIFF
--- a/src/BitPayKeyUtils/Util/Point.php
+++ b/src/BitPayKeyUtils/Util/Point.php
@@ -87,4 +87,23 @@ class Point implements PointInterface
             $this->y
             ) = unserialize($data);
     }
+    
+    /**
+     * @return array
+     */
+    public function __serialize(): array
+    {
+        return array($this->x, $this->y);
+    }
+
+    /**
+     * @param array $data
+     */
+    public function __unserialize(array $data): void
+    {
+        list(
+            $this->x,
+            $this->y
+            ) = $data;
+    }
 }


### PR DESCRIPTION
As of PHP 8.1.0, a class which implements `Serializable` without also implementing `__serialize()` and `__unserialize()` will generate a deprecation warning.
- from https://www.php.net/manual/en/class.serializable.php

The added two functions are not used but remove the warnings.