### PR TITLE
SP-199 Add __serialize() and __unserialize to handle deprecation

### DIFF
--- a/src/BitPayKeyUtils/Util/Point.php
+++ b/src/BitPayKeyUtils/Util/Point.php
@@ -72,9 +72,28 @@ class Point implements PointInterface
     /**
      * @inheritdoc
      */
+    public function __serialize()
+    {
+        return serialize(array($this->x, $this->y));
+    }
+
+    /**
+     * @inheritdoc
+     */
     public function serialize()
     {
         return serialize(array($this->x, $this->y));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function __unserialize($data)
+    {
+        list(
+            $this->x,
+            $this->y
+            ) = unserialize($data);
     }
 
     /**


### PR DESCRIPTION
# Overview

Per the [PHP documentation](https://www.php.net/manual/en/class.serializable.php), Serializable is being deprecated as of PHP 8.1. To temporarily comply with the warning, we are implementing `__serialize()` and `__unserialize()` to function in the same manner as our `serialize()` and `unserialize()` function.

## Warning

> As of PHP 8.1.0, a class which implements Serializable without also implementing [__serialize()](https://www.php.net/manual/en/language.oop5.magic.php#object.serialize) and [__unserialize()](https://www.php.net/manual/en/language.oop5.magic.php#object.unserialize) will generate a deprecation warning.

## Errors
```
Deprecated: BitPayKeyUtils\Util\Point implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)

Deprecated: BitPayKeyUtils\KeyHelper\PrivateKey implements the Serializable interface, which is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)

Deprecated: BitPayKeyUtils\KeyHelper\PublicKey implements the Serializable interface, which is deprecated.
```