### PR TITLE
SP-804 Use PHPUnit 9.6.16 for v1.1.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
           configuration: phpunit.xml
           php_version: ${{ matrix.php-version }}
           php_extensions: bcmath gmp xdebug
+          version: 9.6.9
   phpcs:
     runs-on: ubuntu-latest
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,6 @@
 name: Test
 
-on:
-  push:
-    branches-ignore:
-      - 'master'
+on: [push, pull_request]
 
 jobs:
   phpunit:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           configuration: phpunit.xml
           php_version: ${{ matrix.php-version }}
           php_extensions: bcmath gmp xdebug
-          version: 9.6.9
+          version: 9.6.16
   phpcs:
     runs-on: ubuntu-latest
     


### PR DESCRIPTION
## Overview

This pull request resolves an issue with GitHub Actions where it was always using the latest version. Since the PHP Key Utilities v1.1.x supports PHP 7.4, 8.0, and 8.1, I've locked it to 9.6.16.