### PR TITLE
Dependency updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ examples/.DS_Store
 .phpunit.cache/
 .phpunit.result.cache
 test/unit/_html
-test/unit/BitPayKeyUtils/Storage/*.txt
+test/unit/BitPayKeyUtils/Storage/test1.txt
+test/unit/BitPayKeyUtils/Storage/test11.txt

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ examples/.DS_Store
 .phpunit.cache/
 .phpunit.result.cache
 test/unit/_html
+test/unit/BitPayKeyUtils/Storage/*.txt

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,6 @@
     "phpunit/phpunit": "^10.5.48"
   },
   "suggest": {
-    "ext-gmp": "Required to use this package with GMP instead of BCMath"
+    "ext-gmp": "GMP provides better performance than BCMath"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "ext-iconv": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "10.5.45"
+    "phpunit/phpunit": "^10.5.48"
   },
   "suggest": {
     "ext-gmp": "Required to use this package with GMP instead of BCMath"

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec588010ec8bd4f569dce2950f1f1ac8",
+    "content-hash": "5665b78c8c5f0b2720b482e3fc71488f",
     "packages": [],
     "packages-dev": [
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.1",
+            "version": "1.13.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
+                "reference": "faed855a7b5f4d4637717c2b3863e277116beb36"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/faed855a7b5f4d4637717c2b3863e277116beb36",
+                "reference": "faed855a7b5f4d4637717c2b3863e277116beb36",
                 "shasum": ""
             },
             "require": {
@@ -57,7 +57,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.3"
             },
             "funding": [
                 {
@@ -65,20 +65,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T17:47:46+00:00"
+            "time": "2025-07-05T12:25:42+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.4.0",
+            "version": "v5.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
+                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/221b0d0fdf1369c71047ad1d18bb5880017bbc56",
+                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56",
                 "shasum": ""
             },
             "require": {
@@ -121,9 +121,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.0"
             },
-            "time": "2024-12-30T11:07:19+00:00"
+            "time": "2025-07-27T20:03:57+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -566,16 +566,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.45",
+            "version": "10.5.48",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "bd68a781d8e30348bc297449f5234b3458267ae8"
+                "reference": "6e0a2bc39f6fae7617989d690d76c48e6d2eb541"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bd68a781d8e30348bc297449f5234b3458267ae8",
-                "reference": "bd68a781d8e30348bc297449f5234b3458267ae8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6e0a2bc39f6fae7617989d690d76c48e6d2eb541",
+                "reference": "6e0a2bc39f6fae7617989d690d76c48e6d2eb541",
                 "shasum": ""
             },
             "require": {
@@ -585,7 +585,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.1",
+                "myclabs/deep-copy": "^1.13.3",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
@@ -647,7 +647,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.45"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.48"
             },
             "funding": [
                 {
@@ -659,11 +659,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-06T16:08:12+00:00"
+            "time": "2025-07-11T04:07:17+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1634,7 +1642,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -1645,6 +1653,6 @@
         "ext-json": "*",
         "ext-iconv": "*"
     },
-    "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }

--- a/src/BitPayKeyUtils/Util/Util.php
+++ b/src/BitPayKeyUtils/Util/Util.php
@@ -19,9 +19,7 @@ class Util
 
     /**
      * Computes a digest hash value for the given data using
-     * the given method, and returns a raw or binhex encoded
-     * string, see:
-     * http://us1.php.net/manual/en/function.openssl-digest.php
+     * the hash function.
      *
      * @param string $data
      *
@@ -29,7 +27,7 @@ class Util
      */
     public static function sha512($data)
     {
-        return openssl_digest($data, 'sha512');
+        return hash('sha512', $data);
     }
 
     /**
@@ -68,7 +66,7 @@ class Util
      */
     public static function ripe160($data, $binary = false)
     {
-        return openssl_digest($data, 'ripemd160', $binary);
+        return hash('ripemd160', $data, $binary);
     }
 
     /**
@@ -84,7 +82,7 @@ class Util
      */
     public static function sha256($data, $binary = false)
     {
-        return openssl_digest($data, 'SHA256', $binary);
+        return hash('sha256', $data, $binary);
     }
 
     /**


### PR DESCRIPTION
OpenSSL 3.0 (Nov 2021): RIPEMD160 was moved to the legacy provider and disabled by default [OpenSSL Library](https://openssl-library.org/news/openssl-3.0-notes/)[OpenSSL](https://www.openssl.org/blog/blog/2022/10/18/rmd160-and-the-legacy-provider/index.html)

OpenSSL 3.0.7 (Nov 2022): RIPEMD160 was added back to the default provider [OpenSSL](https://docs.openssl.org/3.0/man7/OSSL_PROVIDER-default/)[OpenSSL](https://docs.openssl.org/master/man7/EVP_MD-RIPEMD160/) due to popular demand

I'm moving to `hash()` function because it's behavior is more consistent